### PR TITLE
Add GitHub community health files & mandatory AGNOS clause for AI-agent contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,117 @@
+# RQ-GOV-004, RQ-GOV-008 / ADR-GOV-001 (DEC-GOV-001)
+name: "🐞 Bug Report"
+description: Report a problem you encountered while using Xplorer.
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill in every
+        field below as precisely as you can. This structured form exists so
+        that a maintainer — or an AI assistant reading it — can understand
+        and act on your report accurately without needing to ask follow-up
+        questions, even if you are not a developer.
+
+  - type: input
+    id: version
+    attributes:
+      label: Xplorer version or build
+      description: >
+        The version shown in Help > About, or the build/commit identifier
+        if you compiled it yourself (e.g. an alpha tag such as
+        "alpha-123-abcdef", or a release tag such as "v2025.12.7.1"). If
+        you are not sure, say so rather than leaving a guess.
+      placeholder: "e.g. alpha-123-abcdef"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Operating system
+      description: The platform you ran Xplorer on when the problem occurred.
+      options:
+        - Windows
+        - macOS
+        - Linux
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: synth
+    attributes:
+      label: Synthesizer
+      description: Which hardware were you connected to (if any) when the problem occurred?
+      options:
+        - Oberheim Xpander
+        - Oberheim Matrix-12
+        - None / not connected to hardware
+        - Not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: >
+        Describe the problem in one or two plain-language sentences — what
+        did you expect, and what happened instead?
+      placeholder: "Example: when I click Save, the application closes instead of saving the patch."
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: >
+        List the exact steps, in order, that lead to the problem. Be as
+        specific as possible — this is what lets someone else reproduce it.
+      placeholder: |
+        1. Open Xplorer
+        2. Load patch "xyz.syx"
+        3. Click Save
+        4. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: >
+        What actually happened instead? Include the exact wording of any
+        error message that was shown.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots or additional context
+      description: >
+        Optional — paste any relevant log output, or drag and drop
+        screenshots/screen recordings here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I have read and agree to follow the [Code of Conduct](../../CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# RQ-GOV-004, RQ-GOV-005 / ADR-GOV-001 (DEC-GOV-005)
+# Blank issues are disabled: every bug report or feature request must go
+# through one of the structured forms in this folder, so intake is never
+# ambiguous or incomplete.
+blank_issues_enabled: false
+contact_links:
+  - name: Contributing & AGNOS process
+    url: https://github.com/xplorer2716/XplorerEditor/blob/main/CONTRIBUTING.md
+    about: Read before contributing code — mandatory reading if you use an AI coding agent.
+  - name: Project website
+    url: http://xplorer.programmer.free.fr
+    about: General information about Xplorer (not for bug reports or feature requests).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,67 @@
+# RQ-GOV-005, RQ-GOV-008 / ADR-GOV-001 (DEC-GOV-001)
+name: "✨ Feature Request"
+description: Suggest an idea or improvement for Xplorer.
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Separating the *problem* from
+        the *solution* below helps a maintainer — or an AI assistant reading
+        this issue — understand what you actually need, not just what you
+        happen to be asking for.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: >
+        What problem are you trying to solve, or what feels missing or
+        frustrating today? Describe the situation, not the fix.
+      placeholder: "Example: there is no way to rename a patch without going through the synth panel."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like Xplorer to do instead? Be as concrete as you can.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area impacted
+      description: Which part of Xplorer does this concern?
+      options:
+        - User interface
+        - MIDI communication
+        - Patch management (load / save / backup)
+        - Build / CI / packaging
+        - Documentation
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        Optional — any workaround you currently use, or other approaches
+        you considered instead of this one.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: I have read and agree to follow the [Code of Conduct](../../CODE_OF_CONDUCT.md).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+<!-- RQ-GOV-006 / ADR-GOV-001 (DEC-GOV-004) -->
+
+## Description
+
+<!-- What does this change do, and why? -->
+
+## Related issue(s)
+
+<!-- e.g. "Fixes #123" or "Relates to #123". Write "None" if there is no related issue. -->
+
+## AGNOS traceability
+
+<!--
+If this change touches process/-managed areas, or was prepared with the
+help of an AI coding agent (RQ-GOV-003), list the requirement / ADR / task
+IDs it implements below. Write "N/A" only for changes with no traceable
+requirement (e.g. a typo fix) — see CONTRIBUTING.md.
+-->
+
+- Requirement(s): <!-- e.g. RQ-GOV-004 -->
+- ADR(s): <!-- e.g. ADR-GOV-001 -->
+- Task(s): <!-- e.g. TASK-GOV-003 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Build / CI / tooling
+- [ ] Other (please describe above)
+
+## Checklist
+
+- [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md).
+- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] The project builds and its tests pass locally.
+- [ ] Documentation (`README.md`, `process/`) is updated if this change affects it.
+- [ ] **If this PR was prepared with the help of an AI coding agent** (GitHub Copilot, Claude Code, or similar), **I confirm it followed the AGNOS process** described in [CONTRIBUTING.md](../CONTRIBUTING.md) — the traceability IDs above are filled in accordingly.
+
+## Screenshots
+
+<!-- For UI changes, before/after screenshots make review much faster. Delete this section if not applicable. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,125 @@
+<!-- RQ-GOV-001 / ADR-GOV-001 (DEC-GOV-003) -->
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education,
+socio-economic status, nationality, personal appearance, race, religion, or
+sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political
+  attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem inappropriate,
+threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, and will communicate reasons
+for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces of this
+repository (issues, pull requests, discussions), and also applies when an
+individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer, [@xplorer2716](https://github.com/xplorer2716),
+via a private GitHub message. All complaints will be reviewed and
+investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of this
+Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior
+deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from project maintainers,
+providing clarity around the nature of the violation and an explanation of
+why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved for a specified period of time. This
+includes avoiding interactions in community spaces as well as external
+channels. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of
+individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+<!-- RQ-GOV-002, RQ-GOV-003 / ADR-GOV-001 (DEC-GOV-002) -->
+
+# Contributing to Xplorer
+
+Thanks for your interest in contributing. This document is the single
+entry point for reporting bugs, requesting features, and submitting code.
+Please also read the [Code of Conduct](CODE_OF_CONDUCT.md) — participation
+in this project requires following it.
+
+## Reporting a bug or requesting a feature
+
+Do not open a blank issue — it is disabled on this repository. Instead,
+pick the template that matches:
+
+- **Bug** → [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml)
+- **Feature / enhancement** → [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml)
+
+Both are structured forms with required fields. This is deliberate and
+non-negotiable, for three reasons:
+1. it tells you exactly what information is needed, so you don't have to
+   guess;
+2. it gives the maintainer unambiguous, directly actionable information,
+   with no back-and-forth to fill in gaps;
+3. every field carries a plain-language description, so the raw submission
+   can be read and accurately summarised — by the maintainer or by an AI
+   assistant — even by someone with no technical background.
+
+## Submitting code changes
+
+1. Fork the repository.
+2. Create a branch for your change (`git checkout -b my-fix`).
+3. Make your change, following the build/test instructions in
+   [README.md](README.md) for the [juce](juce) tree.
+4. Open a Pull Request using the
+   [PR template](.github/PULL_REQUEST_TEMPLATE.md) (pre-filled
+   automatically) and link the issue it addresses, if any.
+5. Respond to review feedback; a maintainer will merge once the checklist
+   is satisfied.
+
+All contributions are made under the project's license — see
+[LICENSE](LICENSE) (GPL v3).
+
+## Mandatory: using an AI coding agent
+
+**If you use an AI coding agent — GitHub Copilot, Claude Code, or any
+equivalent tool — to prepare a contribution to this repository, that agent
+SHALL follow the project's AGNOS software engineering process. This is not
+optional or a suggestion: it is a non-negotiable requirement for any
+AI-agent-assisted contribution.**
+
+This repository is developed using the **AGNOS lightweight agentic
+development process** — requirements, architecture decisions, plans and
+tasks, all cross-referenced with traceable IDs, so that every change stays
+explainable and auditable. The full, authoritative procedure is defined
+here and is **not duplicated in this document**, to avoid the two copies
+drifting apart:
+
+- **Process definition**: [.github/instructions/agnos-sw-eng.v2.instructions.md](.github/instructions/agnos-sw-eng.v2.instructions.md)
+- **Claude Code entry point**: [CLAUDE.md](CLAUDE.md) (tool-specific mapping onto the process above)
+
+In short, an AI agent preparing a change here is expected to author or
+reference the relevant requirement (`RQ-*`), architecture decision
+(`ADR-*`) and task (`TASK-*`) artifacts under [process](process), and to
+carry those IDs into commit messages and code comments — read the linked
+instructions for the exact rules rather than relying on this summary.
+
+Pull requests that show signs of AI-agent assistance (e.g. an
+AI-authored-looking description, or changes to `process/`-managed areas)
+without this traceability will be sent back for revision before review —
+see the [Pull Request template](.github/PULL_REQUEST_TEMPLATE.md)
+checklist.
+
+Contributions prepared without an AI agent are not required to run the
+full AGNOS session ceremony (session state, feature branches, ADRs) —
+follow the plain workflow above.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,17 @@ AI-agent-assisted contribution.**
 This repository is developed using the **AGNOS lightweight agentic
 development process** — requirements, architecture decisions, plans and
 tasks, all cross-referenced with traceable IDs, so that every change stays
-explainable and auditable. The full, authoritative procedure is defined
-here and is **not duplicated in this document**, to avoid the two copies
-drifting apart:
+explainable and auditable. The process definition is written to be
+tool-neutral and is directly executable by both **GitHub Copilot** and
+**Claude Code**. The full, authoritative procedure is defined once and is
+**not duplicated in this document**, to avoid multiple copies drifting
+apart:
 
-- **Process definition**: [.github/instructions/agnos-sw-eng.v2.instructions.md](.github/instructions/agnos-sw-eng.v2.instructions.md)
-- **Claude Code entry point**: [CLAUDE.md](CLAUDE.md) (tool-specific mapping onto the process above)
+- **Process definition (tool-neutral, authoritative)**: [.github/instructions/agnos-sw-eng.v2.instructions.md](.github/instructions/agnos-sw-eng.v2.instructions.md) — GitHub Copilot discovers and applies this file natively (standard `.github/instructions/` convention); no extra setup is required for Copilot.
+- **Claude Code entry point**: [CLAUDE.md](CLAUDE.md) — Claude Code does not auto-discover `.github/instructions/`, so this file imports the process definition above and maps its two tool-specific touch points (the user-question tool, the git workflow skill) onto Claude Code's equivalents.
+
+Whichever agent you use, the process it must follow is the same one; only
+the entry point differs.
 
 In short, an AI agent preparing a change here is expected to author or
 reference the relevant requirement (`RQ-*`), architecture decision

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With Xplorer you can tweak the sound simultaneously using a computer mouse, a ha
 Xplorer is being migrated from its original .NET/WinForms implementation to a cross-platform **JUCE/C++20** implementation. The JUCE port is the active development effort and lives under [juce](juce). Most features are already available; if you want to test it before the official release, compile it from the `main` branch source code — on Windows, run [make-windows-local-release-no-tests](make-windows-local-release-no-tests) (CMake + MSVC), or configure the [juce](juce) CMake project directly on any platform.
 
 - **Alpha preview available**: the latest JUCE development version for Windows and macOS is available as an alpha preview in the releases stream: https://github.com/xplorer2716/XplorerEditor/releases
-- **Latest official (.NET) release**: [v2025.12.7.1](https://github.com/xplorer2716/XplorerEditor/releases/latest) — the next official release (JUCE-based) will be published in the same release stream
+- **Latest official (.NET) release**: [v2025.12.7.1](https://github.com/xplorer2716/XplorerEditor/releases/latest) — the next official release (JUCE-based) will be published in the same releases stream
 
 - **Legacy .NET source code**: archived at [xplorer2716/XplorerEditor-dotnet-archive](https://github.com/xplorer2716/XplorerEditor-dotnet-archive)
 
@@ -40,9 +40,12 @@ Xplorer is being migrated from its original .NET/WinForms implementation to a cr
 ### What's new in the JUCE port
 
 - **Vector-drawn, resizable user interface** — the whole panel (background, block frames, signal-path diagram) is drawn with vector primitives instead of a fixed bitmap, so it stays crisp at any window size and on high-resolution displays
-- **Colour-coded functional blocks** — VCO, VCF, ENV, LFO, RAMP, LAG, TRACK and the Modulation Matrix each carry their own colour identity (frame, fill and section header), making the signal-path diagram easier to read at a glance
+- **Window size presets & full screen** — a View menu offers five size presets (1x to 2x) plus full screen, falling back to full screen automatically when a preset doesn't fit the display; the VFD's glyph grid is snapped to whole device pixels so text stays equally crisp at every scale
+- **Colour-coded functional blocks** — VCO, VCF, ENV, LFO, RAMP, LAG, TRACK and the Modulation Matrix each carry their own colour identity (frame, fill and section header), with a live modulation-matrix highlight, making the signal-path diagram easier to read at a glance
+- **Refined VFD display** — a recessed bezel and vector-drawn segments, with the three MIDI-activity indicators redesigned as glowing lamps instead of flat squares
+- **Reference-aligned menu bar** — menu order, icons and keyboard shortcuts now match the original hardware editor exactly
 - **Native cross-platform target** — Windows, Linux and macOS, on a modern C++20/JUCE stack with no legacy third-party framework dependency, and a future path to run as a plugin inside DAWs
-- **Modernised interaction feedback** — consistent hover/keyboard-focus/disabled states across every control, radio-button selectors matching the reference hardware panel (e.g. FM destination, LAG timing), and a live modulation-matrix highlight
+- **Modernised interaction feedback** — consistent hover and disabled states across every control, radio-button selectors matching the reference hardware panel (e.g. FM destination, LAG timing), and instant startup with no splash screen
 
 This port also aims to demonstrate the integration of AI software development agents such as GitHub Copilot and Claude Code into the SDLC, by following a strict process and ensuring end-to-end traceability, using the AGNOS lightweight agentic development process (see the [process](process) folder).
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ With Xplorer you can tweak the sound simultaneously using a computer mouse, a ha
 
 ## Status
 
-Xplorer is being migrated from its original .NET/WinForms implementation to a cross-platform **JUCE/C++20** implementation. The JUCE port is the active development effort and lives under [juce](juce). Most features are already available; if you want to test it before the official release, compile it from the `main` branch source code — on Windows, run [make-windows-local.bat](make-windows-local.bat) (CMake + MSVC), or configure the [juce](juce) CMake project directly on any platform.
+Xplorer is being migrated from its original .NET/WinForms implementation to a cross-platform **JUCE/C++20** implementation. The JUCE port is the active development effort and lives under [juce](juce). Most features are already available; if you want to test it before the official release, compile it from the `main` branch source code — on Windows, run [make-windows-local-release-no-tests](make-windows-local-release-no-tests) (CMake + MSVC), or configure the [juce](juce) CMake project directly on any platform.
+
+- **Alpha preview available**: the latest JUCE development version for Windows and macOS is available as an alpha preview in the releases stream: https://github.com/xplorer2716/XplorerEditor/releases
+- **Latest official (.NET) release**: [v2025.12.7.1](https://github.com/xplorer2716/XplorerEditor/releases/latest) — the next official release (JUCE-based) will be published in the same release stream
 
 - **Legacy .NET source code**: archived at [xplorer2716/XplorerEditor-dotnet-archive](https://github.com/xplorer2716/XplorerEditor-dotnet-archive)
-- **Latest official (.NET) release**: [v2025.12.7.1](https://github.com/xplorer2716/XplorerEditor/releases/tag/v2025.12.7.1) — the next official release (JUCE-based) will be published in the same release stream
+
 
 ## Main features
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ This port also aims to demonstrate the integration of AI software development ag
 - [juce](juce): active JUCE-based source tree (build instructions, CMake setup)
 - [process](process): AGNOS requirements / architecture-decision / plan artifacts
 
-## Contributing
+## Community
 
-1. Fork the repository
-2. Create a new branch (`git checkout -b feature/YourFeature`)
-3. Commit your changes (`git commit -m 'Add some feature'`)
-4. Push to the branch (`git push origin feature/YourFeature`)
-5. Open a Pull Request and describe your changes
+- Found a bug or have an idea? Open an issue using the
+  [Bug Report](https://github.com/xplorer2716/XplorerEditor/issues/new?template=bug_report.yml) or
+  [Feature Request](https://github.com/xplorer2716/XplorerEditor/issues/new?template=feature_request.yml) form.
+- Want to contribute code? See [CONTRIBUTING.md](CONTRIBUTING.md) — it
+  covers the workflow and, if you use an AI coding agent (GitHub Copilot,
+  Claude Code, ...), the mandatory AGNOS process.
+- This project follows a [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Credits
 

--- a/process/1.requirements/RQ-GOV-community-and-contribution.md
+++ b/process/1.requirements/RQ-GOV-community-and-contribution.md
@@ -1,0 +1,204 @@
+# RQ-GOV — Community Health & Contribution Standards
+
+Scope: the repository's public-facing governance surface — Code of Conduct,
+contribution workflow, issue intake, and pull-request intake — so that
+external contributors (human or AI-agent-assisted) have one unambiguous,
+non-negotiable path into the project, and maintainers (human or AI) receive
+structured, machine-parseable input instead of free-text issues. Distinct
+functional area from the JUCE application requirements (RQ-GUI-*, RQ-MOD-*,
+etc.) and from build/release tooling (RQ-BLD-*), hence the RQ-GOV-* series.
+
+---
+
+## Functional Requirements
+
+### RQ-GOV-001: Code of Conduct
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: The repository SHALL publish a `CODE_OF_CONDUCT.md` at its
+  root, based on the Contributor Covenant v2.1, stating expected behaviour,
+  unacceptable behaviour, and an enforcement contact.
+- **Rationale**: a published, standard Code of Conduct is a prerequisite for
+  predictable, low-friction community interaction and is one of GitHub's
+  community-standards checklist items.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* the repository root, *When* `CODE_OF_CONDUCT.md` is opened,
+    *Then* it states the standards of behaviour and how to report a
+    violation.
+  - *Given* GitHub's "Community Standards" checklist for this repository,
+    *When* it is viewed, *Then* "Code of conduct" is satisfied.
+- **Dependencies**: None
+
+---
+
+### RQ-GOV-002: Contribution workflow
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: The repository SHALL publish a `CONTRIBUTING.md` at its
+  root describing the standard fork → branch → commit → pull-request
+  workflow, how to report bugs and request features (via RQ-GOV-004/005),
+  and how pull requests are reviewed (via RQ-GOV-006).
+- **Rationale**: a single, discoverable document removes ambiguity for
+  first-time contributors and reduces maintainer triage effort.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* the repository root, *When* `CONTRIBUTING.md` is opened, *Then*
+    it describes the fork/branch/PR workflow and links the issue and PR
+    templates.
+- **Dependencies**: RQ-GOV-004, RQ-GOV-005, RQ-GOV-006
+
+---
+
+### RQ-GOV-003: Mandatory AGNOS process for AI-agent-assisted contributions
+
+- **Category**: Functional
+- **EARS Type**: Event-driven
+- **Statement**: WHEN a contributor uses an AI coding agent (e.g. GitHub
+  Copilot, Claude Code, or an equivalent tool) to prepare a change to this
+  repository, `CONTRIBUTING.md` SHALL state — as a non-negotiable
+  requirement, not a suggestion — that the agent SHALL follow the AGNOS
+  process defined in
+  `.github/instructions/agnos-sw-eng.v2.instructions.md` (Claude Code entry
+  point: `CLAUDE.md`), and SHALL NOT duplicate or paraphrase that process
+  inline; it SHALL link to it as the single source of truth.
+- **Rationale**: the project's stated purpose for the JUCE port includes
+  demonstrating disciplined AI-agent SDLC integration (README "What's new in
+  the JUCE port"); an external contribution prepared by an AI agent without
+  the same traceability discipline (requirement/ADR/task IDs) would break
+  that guarantee and reintroduce the ambiguity AGNOS exists to remove.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* `CONTRIBUTING.md`, *When* it is read, *Then* it states plainly
+    that using an AI coding agent makes following AGNOS mandatory, and links
+    to `.github/instructions/agnos-sw-eng.v2.instructions.md` rather than
+    restating its content.
+  - *Given* a pull request whose description or commits show evidence of
+    AI-agent assistance (e.g. AGNOS traceability IDs absent where the change
+    touches `process/`-managed areas), *When* it is reviewed against the PR
+    template (RQ-GOV-006), *Then* the missing traceability is flagged before
+    merge.
+- **Dependencies**: RQ-GOV-002, RQ-GOV-006
+
+---
+
+### RQ-GOV-004: Structured bug-report issue template
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: The repository SHALL provide a structured bug-report issue
+  form (`.github/ISSUE_TEMPLATE/bug_report.yml`) with required fields
+  covering: Xplorer version/build, platform, affected synthesizer, a
+  summary, reproduction steps, expected behaviour, and actual behaviour.
+  Free-form ("blank") issues SHALL be disabled for bug reports.
+- **Rationale**: a fixed, required-field structure is the only way to make
+  "what information must be provided" non-negotiable — a prose template can
+  be skipped section by section; a GitHub Issue Form with required fields
+  cannot be submitted incomplete. No "implementation" field is needed: the
+  archived .NET codebase (`XplorerEditor-dotnet-archive`) is no longer
+  supported once the JUCE port reaches its first official release (Status
+  section, README), so the JUCE version is the only one the form needs to
+  ask about; the free-text version/build field alone answers "which
+  build".
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a user opens a new issue, *When* they choose "Bug Report",
+    *Then* they cannot submit without filling every field marked required.
+  - *Given* a submitted bug report, *When* a maintainer reads it, *Then*
+    every field required to reproduce the problem (version, platform,
+    steps, expected vs. actual) is present without needing a follow-up
+    question.
+- **Dependencies**: RQ-GOV-008
+
+---
+
+### RQ-GOV-005: Structured feature-request issue template
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: The repository SHALL provide a structured feature-request
+  issue form (`.github/ISSUE_TEMPLATE/feature_request.yml`) with required
+  fields covering: the problem/motivation, the proposed solution, and the
+  impacted area (UI, MIDI, patch management, build/CI, other); an
+  alternatives-considered field SHALL be present and optional.
+- **Rationale**: separates "what problem are you having" from "what do you
+  want built", which is the single most common source of ambiguous feature
+  requests.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a user opens a new issue, *When* they choose "Feature Request",
+    *Then* they cannot submit without describing both the motivation and
+    the proposed solution.
+- **Dependencies**: RQ-GOV-008
+
+---
+
+### RQ-GOV-006: Pull Request template with traceability fields
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: The repository SHALL provide a pull-request template
+  (`.github/PULL_REQUEST_TEMPLATE.md`) requiring: a description of the
+  change, the issue(s) it addresses, the AGNOS requirement/ADR/task IDs it
+  implements (when applicable), a checklist including Code of Conduct
+  acknowledgement and, WHEN the contribution was AI-agent-assisted,
+  confirmation that AGNOS (RQ-GOV-003) was followed.
+- **Rationale**: makes AGNOS non-compliance visible at review time instead
+  of relying on trust, and gives every PR the same minimum reviewable shape.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a new pull request, *When* its description is opened, *Then*
+    the template's sections (description, related issues, traceability
+    IDs, checklist) are pre-filled as placeholders.
+- **Dependencies**: RQ-GOV-003
+
+---
+
+### RQ-GOV-007: README references the governance artifacts
+
+- **Category**: Functional
+- **EARS Type**: Ubiquitous
+- **Statement**: `README.md` SHALL reference `CODE_OF_CONDUCT.md`,
+  `CONTRIBUTING.md`, and the issue/PR templates from a "Contributing" or
+  "Community" section, replacing any contribution instructions duplicated
+  inline.
+- **Rationale**: `README.md` is the repository's entry point; contribution
+  and conduct expectations SHALL be discoverable from there without
+  duplicating content that would drift out of sync with `CONTRIBUTING.md`.
+- **Priority**: Should
+- **Acceptance Criteria** (Gherkin):
+  - *Given* `README.md`, *When* its Contributing/Community section is read,
+    *Then* it links to `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` and does
+    not restate the fork/branch/PR steps inline.
+- **Dependencies**: RQ-GOV-001, RQ-GOV-002
+
+---
+
+## Non-Functional Requirements
+
+### RQ-GOV-008: Issue templates are unambiguous and AI-reformulation-friendly
+
+- **Category**: Non-Functional
+- **NFR Type**: Usability
+- **EARS Type**: Ubiquitous
+- **Statement**: Every issue-form field defined under RQ-GOV-004/RQ-GOV-005
+  SHALL have a plain-language label and description such that (a) a
+  non-technical user knows exactly what to enter, (b) a maintainer receives
+  unambiguous, directly actionable information with no implicit fields, and
+  (c) an AI assistant reading the raw submitted form (field label + value)
+  can accurately reformulate the issue in plain language for a
+  non-technical user without additional clarification.
+- **Metric**: 100% of required fields have a non-empty `description` (or
+  form-field placeholder) explaining, in plain language, what is expected.
+- **Measurement Method**: manual review of each `.yml` issue-form field
+  against the three audiences (submitter, maintainer, AI reader) at
+  authoring time; re-checked whenever a field is added or changed.
+- **Priority**: Must
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a submitted bug report or feature request, *When* its raw field
+    labels and values are given to an AI assistant with no other context,
+    *Then* the assistant can produce an accurate plain-language summary of
+    the issue without inventing information not present in the submission.
+- **Dependencies**: RQ-GOV-004, RQ-GOV-005

--- a/process/2.architecture/ADR-GOV-001-community-health-files-and-issue-template-format.md
+++ b/process/2.architecture/ADR-GOV-001-community-health-files-and-issue-template-format.md
@@ -1,0 +1,132 @@
+# ADR-GOV-001: Community Health Files & Issue Template Format
+
+## Status
+Accepted
+
+<!-- Motivated by RQ-GOV-001..008. New functional area (repository
+governance / contribution intake) distinct from the JUCE UI/model
+architecture (ADR-JUC-*) and build/release tooling (ADR-BLD-*), hence the
+ADR-GOV-* series. -->
+
+## Context
+
+The repository has no standard GitHub community-health files
+(`CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, issue templates, PR template).
+`README.md`'s current "Contributing" section is a five-line generic
+fork/branch/PR list with no traceability to the AGNOS process the project
+otherwise uses for every change (RQ-NFR-007, `CLAUDE.md`), and no
+structured intake for bug reports or feature requests.
+
+Two forces shape the decision:
+1. **Issue intake must be non-negotiable and unambiguous** (owner
+   requirement): a submitter must know exactly what to provide, a
+   maintainer must receive unambiguous, directly actionable information,
+   and — because this project explicitly uses AI coding agents in its own
+   SDLC (README "What's new in the JUCE port") — an AI assistant must be
+   able to read a raw submission and correctly reformulate it in plain
+   language for a non-technical user, with no invented information.
+2. **AI-agent-assisted contributions must follow AGNOS, non-negotiably**
+   (owner requirement): the project's own commits already carry AGNOS
+   traceability (requirement/ADR/task IDs); an external contribution
+   prepared by an AI agent without that discipline would silently
+   reintroduce the ambiguity AGNOS exists to remove.
+
+## Decision
+
+- **DEC-GOV-001 — GitHub Issue Forms (YAML), not free-text Markdown
+  templates.** Bug reports and feature requests SHALL be
+  `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml`, using
+  GitHub's structured Issue Forms schema (`type: input/textarea/dropdown/
+  checkboxes`, `validations: { required: true }`). A required field cannot
+  be submitted empty — this is what makes the standard *enforced*, not just
+  documented. Every field carries a plain-language `label` and
+  `description`, which is also what an AI assistant reads to reformulate
+  the issue (RQ-GOV-004, RQ-GOV-005, RQ-GOV-008).
+
+- **DEC-GOV-002 — `CONTRIBUTING.md` links to the AGNOS instructions; it
+  does not restate them.** The mandatory-AGNOS clause (RQ-GOV-003) points
+  to `.github/instructions/agnos-sw-eng.v2.instructions.md` (and
+  `CLAUDE.md` as the Claude Code entry point) as the single source of
+  truth, mirroring the pattern already established for the git-workflow
+  skill (RQ-PRT-004: ".claude/skills/... points to .github/skills/... as
+  canonical"). Duplicating the process text inline would create a second
+  copy that drifts the first time either is updated.
+
+- **DEC-GOV-003 — Code of Conduct = Contributor Covenant v2.1, verbatim.**
+  Industry-standard text (also what GitHub's own community-profile
+  checklist recognises), so no bespoke wording to maintain or justify.
+  Enforcement contact is the maintainer's GitHub handle (`@xplorer2716`),
+  not an invented email address — the repository does not currently
+  publish a monitored contact email, and fabricating one would be
+  misleading.
+
+- **DEC-GOV-004 — PR template requires explicit traceability IDs and an
+  AI-assistance checkbox.** `.github/PULL_REQUEST_TEMPLATE.md` has a
+  dedicated "AGNOS traceability" field (requirement/ADR/task IDs, "N/A" if
+  none apply) and a checklist item: "If this PR was prepared with the help
+  of an AI coding agent, I confirm it followed the AGNOS process
+  (CONTRIBUTING.md)." This makes non-compliance visible at review time
+  instead of relying on trust (RQ-GOV-006).
+
+- **DEC-GOV-005 — Blank issues disabled.** `.github/ISSUE_TEMPLATE/
+  config.yml` sets `blank_issues_enabled: false`, so every bug/feature
+  submission is forced through one of the two structured forms — this is
+  the mechanism that makes the standard "non-negotiable" rather than one
+  option among several (RQ-GOV-004/005).
+
+## Consequences
+
+- **Easier:** every issue arrives with the same required fields, cutting
+  maintainer triage/clarification round-trips; an AI agent (used by the
+  maintainer or by a contributor) can read a submission's field
+  label/value pairs directly and produce a reliable plain-language summary
+  or a first-pass fix without guessing missing context; PRs are reviewable
+  against one fixed checklist.
+- **Harder / constrained:** contributors must fill more structured fields
+  before submitting an issue than a one-line free-text report; the two
+  `.yml` forms need to be kept in sync (fields, required-ness) whenever the
+  project's supported platforms or implementations change.
+- **Neutral:** zero effect on application code or CI; `CONTRIBUTING.md`'s
+  AGNOS clause applies only when an AI agent is used — a manual,
+  human-only PR is not required to run the full AGNOS session ceremony
+  (session state, feature branch, ADRs), only to follow the general
+  workflow in `CONTRIBUTING.md`.
+
+## Alternatives Considered
+
+- **Plain Markdown issue template (`ISSUE_TEMPLATE.md`, single file):**
+  rejected — no required-field enforcement, a submitter can delete or skip
+  whole sections, and free text is harder for an AI reader to reliably map
+  to "what was actually provided" versus "what the template suggested".
+- **Restating the AGNOS process inline in `CONTRIBUTING.md`:** rejected —
+  violates the single-source-of-truth pattern already established for the
+  git-workflow skill (RQ-PRT-004); two descriptions of the same process
+  will diverge.
+- **A dedicated `SECURITY.md` with a monitored contact email:** deferred,
+  out of scope — not requested by the owner; the Code of Conduct's
+  enforcement contact uses the maintainer's existing GitHub handle instead
+  of an invented address. Revisit as a follow-up if a real security-contact
+  need arises.
+
+## Diagram
+
+```mermaid
+flowchart TD
+    subgraph Issue Intake
+        A["Contributor opens an issue"] --> B{"Bug or Feature?"}
+        B -- "Bug" --> C["bug_report.yml<br/>(required fields, DEC-GOV-001)"]
+        B -- "Feature" --> D["feature_request.yml<br/>(required fields, DEC-GOV-001)"]
+        B -- "Blank" --> E["blocked — config.yml<br/>blank_issues_enabled: false (DEC-GOV-005)"]
+        C --> F["Structured issue<br/>readable by maintainer AND AI (RQ-GOV-008)"]
+        D --> F
+    end
+    subgraph Contribution Workflow
+        G["Contributor forks / branches"] --> H{"AI coding agent used?<br/>(Copilot, Claude Code, ...)"}
+        H -- "Yes" --> I["MUST follow AGNOS<br/>(.github/instructions/agnos-sw-eng.v2, DEC-GOV-002)"]
+        H -- "No" --> J["Standard fork/branch/PR workflow<br/>(CONTRIBUTING.md)"]
+        I --> K["Pull Request<br/>PULL_REQUEST_TEMPLATE.md (DEC-GOV-004)"]
+        J --> K
+        K --> L["Maintainer review:<br/>traceability IDs + AI checkbox verified"]
+    end
+    F -.->|"may become"| G
+```

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -55,7 +55,7 @@ runs last.
 
 ### TASK-GOV-002: Author Contributing Guide
 - **Tier**: M
-- **Status**: Not Started
+- **Status**: Done
 - **Description**: Add `CONTRIBUTING.md` describing the fork/branch/PR
   workflow, links to the issue templates (TASK-GOV-003) and PR template
   (TASK-GOV-004), and the non-negotiable clause: any contribution prepared

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -75,7 +75,7 @@ runs last.
 
 ### TASK-GOV-003: Author structured issue templates
 - **Tier**: M
-- **Status**: Not Started
+- **Status**: Done
 - **Description**: Add `.github/ISSUE_TEMPLATE/bug_report.yml`,
   `feature_request.yml` (GitHub Issue Forms, required fields, DEC-GOV-001)
   and `config.yml` (`blank_issues_enabled: false`, DEC-GOV-005). Every

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -111,7 +111,7 @@ runs last.
 
 ### TASK-GOV-005: Update README Contributing/Community section
 - **Tier**: S
-- **Status**: Not Started
+- **Status**: Done
 - **Description**: Replace `README.md`'s inline fork/branch/PR list with a
   short Community/Contributing section linking `CONTRIBUTING.md` and
   `CODE_OF_CONDUCT.md`.
@@ -130,4 +130,6 @@ runs last.
 
 - [x] Each task has a description, Gherkin acceptance criteria and a tier.
 - [x] Each task references its requirement and ADR IDs.
-- [ ] **Owner approval** — pending.
+- [x] **Owner approval** — granted 2026-08-05 (RQ-GOV-004 amended to drop the
+      .NET dropdown per owner instruction before implementation started).
+- [x] All five tasks Done.

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -94,7 +94,7 @@ runs last.
 
 ### TASK-GOV-004: Author Pull Request template
 - **Tier**: M
-- **Status**: Not Started
+- **Status**: Done
 - **Description**: Add `.github/PULL_REQUEST_TEMPLATE.md` with description,
   related-issue, AGNOS-traceability-IDs fields and a checklist including
   Code of Conduct acknowledgement and the AI-assistance/AGNOS-compliance

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -1,0 +1,133 @@
+# PLAN-GOV-001: Community Health & Contribution Standards
+
+## Overview
+
+Create the repository's standard GitHub community-health surface — Code of
+Conduct, contribution guide, structured issue templates, pull-request
+template — and point `README.md` at them, so external contribution and
+issue intake follow one non-negotiable, unambiguous, AI-parseable standard
+instead of the current five-line generic list in `README.md`.
+
+## References
+
+- **Requirements**: RQ-GOV-001 … RQ-GOV-008 (`RQ-GOV-community-and-contribution.md`)
+- **ADRs**: ADR-GOV-001 (DEC-GOV-001 … DEC-GOV-005)
+
+Session state: `unit_tests = false`, `platform = windows`, `chat_mode = normal`.
+Branch: `feature/GOV`.
+
+This plan implements the tasks in the format specified by the AGNOS process.
+
+---
+
+## Tasks
+
+| Task | Description | Tier | RQ / ADR |
+|------|-------------|:-:|---|
+| TASK-GOV-001 | Author `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1) | M | RQ-GOV-001, ADR-GOV-001 (DEC-GOV-003) |
+| TASK-GOV-002 | Author `CONTRIBUTING.md` incl. mandatory-AGNOS clause | M | RQ-GOV-002, RQ-GOV-003, ADR-GOV-001 (DEC-GOV-002) |
+| TASK-GOV-003 | Author structured issue templates (bug report, feature request, config) | M | RQ-GOV-004, RQ-GOV-005, RQ-GOV-008, ADR-GOV-001 (DEC-GOV-001, DEC-GOV-005) |
+| TASK-GOV-004 | Author `PULL_REQUEST_TEMPLATE.md` | M | RQ-GOV-006, ADR-GOV-001 (DEC-GOV-004) |
+| TASK-GOV-005 | Update `README.md` Contributing/Community section | S | RQ-GOV-007 |
+
+No cross-task code dependency — each produces an independent file — but
+TASK-GOV-005 (README) references the artifacts produced by 001-004, so it
+runs last.
+
+---
+
+### TASK-GOV-001: Author Code of Conduct
+- **Tier**: M
+- **Status**: Done
+- **Description**: Add `CODE_OF_CONDUCT.md` at the repository root, the
+  Contributor Covenant v2.1 text (DEC-GOV-003), enforcement contact set to
+  the maintainer's GitHub handle.
+- **Requirement refs**: RQ-GOV-001
+- **ADR refs**: ADR-GOV-001 (DEC-GOV-003)
+- **Acceptance Criteria** (Gherkin):
+  - *Given* the repository root, *When* `CODE_OF_CONDUCT.md` is opened,
+    *Then* it states expected/unacceptable behaviour and an enforcement
+    contact.
+- **Dependencies**: None
+- **Assignee**: AI
+
+---
+
+### TASK-GOV-002: Author Contributing Guide
+- **Tier**: M
+- **Status**: Not Started
+- **Description**: Add `CONTRIBUTING.md` describing the fork/branch/PR
+  workflow, links to the issue templates (TASK-GOV-003) and PR template
+  (TASK-GOV-004), and the non-negotiable clause: any contribution prepared
+  with an AI coding agent SHALL follow AGNOS
+  (`.github/instructions/agnos-sw-eng.v2.instructions.md`, entry point
+  `CLAUDE.md`), linked rather than restated (DEC-GOV-002).
+- **Requirement refs**: RQ-GOV-002, RQ-GOV-003
+- **ADR refs**: ADR-GOV-001 (DEC-GOV-002)
+- **Acceptance Criteria** (Gherkin):
+  - *Given* `CONTRIBUTING.md`, *When* read, *Then* it links (not
+    duplicates) the AGNOS instructions and states the AI-agent clause as
+    mandatory.
+- **Dependencies**: None
+- **Assignee**: AI
+
+---
+
+### TASK-GOV-003: Author structured issue templates
+- **Tier**: M
+- **Status**: Not Started
+- **Description**: Add `.github/ISSUE_TEMPLATE/bug_report.yml`,
+  `feature_request.yml` (GitHub Issue Forms, required fields, DEC-GOV-001)
+  and `config.yml` (`blank_issues_enabled: false`, DEC-GOV-005). Every
+  field carries a plain-language label/description satisfying RQ-GOV-008.
+- **Requirement refs**: RQ-GOV-004, RQ-GOV-005, RQ-GOV-008
+- **ADR refs**: ADR-GOV-001 (DEC-GOV-001, DEC-GOV-005)
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a new issue, *When* "Bug Report" or "Feature Request" is
+    chosen, *Then* required fields block submission until filled.
+  - *Given* the "New Issue" page, *When* opened, *Then* no blank/free-form
+    option is offered.
+- **Dependencies**: None
+- **Assignee**: AI
+
+---
+
+### TASK-GOV-004: Author Pull Request template
+- **Tier**: M
+- **Status**: Not Started
+- **Description**: Add `.github/PULL_REQUEST_TEMPLATE.md` with description,
+  related-issue, AGNOS-traceability-IDs fields and a checklist including
+  Code of Conduct acknowledgement and the AI-assistance/AGNOS-compliance
+  checkbox (DEC-GOV-004).
+- **Requirement refs**: RQ-GOV-006
+- **ADR refs**: ADR-GOV-001 (DEC-GOV-004)
+- **Acceptance Criteria** (Gherkin):
+  - *Given* a new pull request, *When* opened, *Then* the description box
+    is pre-filled with the template's sections.
+- **Dependencies**: None
+- **Assignee**: AI
+
+---
+
+### TASK-GOV-005: Update README Contributing/Community section
+- **Tier**: S
+- **Status**: Not Started
+- **Description**: Replace `README.md`'s inline fork/branch/PR list with a
+  short Community/Contributing section linking `CONTRIBUTING.md` and
+  `CODE_OF_CONDUCT.md`.
+- **Requirement refs**: RQ-GOV-007
+- **ADR refs**: None
+- **Acceptance Criteria** (Gherkin):
+  - *Given* `README.md`, *When* its Contributing section is read, *Then* it
+    links to `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` with no duplicated
+    step-by-step instructions.
+- **Dependencies**: TASK-GOV-001, TASK-GOV-002
+- **Assignee**: AI
+
+---
+
+## Definition of Ready
+
+- [x] Each task has a description, Gherkin acceptance criteria and a tier.
+- [x] Each task references its requirement and ADR IDs.
+- [ ] **Owner approval** — pending.

--- a/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
+++ b/process/3.plan/PLAN-GOV-001-community-health-and-contribution-standards.md
@@ -29,6 +29,7 @@ This plan implements the tasks in the format specified by the AGNOS process.
 | TASK-GOV-003 | Author structured issue templates (bug report, feature request, config) | M | RQ-GOV-004, RQ-GOV-005, RQ-GOV-008, ADR-GOV-001 (DEC-GOV-001, DEC-GOV-005) |
 | TASK-GOV-004 | Author `PULL_REQUEST_TEMPLATE.md` | M | RQ-GOV-006, ADR-GOV-001 (DEC-GOV-004) |
 | TASK-GOV-005 | Update `README.md` Contributing/Community section | S | RQ-GOV-007 |
+| TASK-GOV-006 | Correct "What's new in the JUCE port" README section (stale focus-indicator claim; missing shipped GFX improvements) | S | RQ-GUI-054/055/056, RQ-SCL-001..004, ADR-JUC-023/024/025/026/029/030/031/032 |
 
 No cross-task code dependency — each produces an independent file — but
 TASK-GOV-005 (README) references the artifacts produced by 001-004, so it
@@ -126,10 +127,39 @@ runs last.
 
 ---
 
+### TASK-GOV-006: Correct "What's new in the JUCE port" README section
+- **Tier**: S
+- **Status**: Done
+- **Description**: The section claimed a keyboard-focus visual indicator,
+  which ADR-JUC-029 removed (owner: "l'histoire du focus ce n'est plus
+  vrai"). Corrected the claim and added the other shipped GFX-session
+  improvements the section had not caught up with: window size presets /
+  full screen and device-pixel-snapped VFD glyph grid (ADR-JUC-025/026),
+  recessed VFD bezel and vector segment rendering (ADR-JUC-023/024), the
+  MIDI-activity lamp redesign (ADR-JUC-031), the reference-aligned menu bar
+  (ADR-JUC-032), and splash-screen removal (ADR-JUC-030). No new
+  requirement or ADR — this traces to artifacts that already exist and are
+  Accepted; the task only brings README's marketing copy back in sync with
+  what actually shipped.
+- **Requirement refs**: RQ-GUI-054, RQ-GUI-055, RQ-GUI-056, RQ-SCL-001,
+  RQ-SCL-002, RQ-SCL-003, RQ-SCL-004
+- **ADR refs**: ADR-JUC-023, ADR-JUC-024, ADR-JUC-025, ADR-JUC-026,
+  ADR-JUC-029, ADR-JUC-030, ADR-JUC-031, ADR-JUC-032
+- **Acceptance Criteria** (Gherkin):
+  - *Given* `README.md`'s "What's new in the JUCE port" section, *When*
+    read, *Then* it makes no claim about a keyboard-focus indicator.
+  - *Given* that section, *When* read against the ADR-JUC-023/024/025/026/
+    030/031/032 Consequences sections, *Then* every remaining claim is
+    still true.
+- **Dependencies**: None
+- **Assignee**: AI
+
+---
+
 ## Definition of Ready
 
 - [x] Each task has a description, Gherkin acceptance criteria and a tier.
 - [x] Each task references its requirement and ADR IDs.
 - [x] **Owner approval** — granted 2026-08-05 (RQ-GOV-004 amended to drop the
       .NET dropdown per owner instruction before implementation started).
-- [x] All five tasks Done.
+- [x] All six tasks Done.

--- a/process/_sessionstate/session.yaml
+++ b/process/_sessionstate/session.yaml
@@ -1,3 +1,3 @@
-unit_tests: true       # boolean — user variable: generate and run unit tests
+unit_tests: false      # boolean — user variable: generate and run unit tests
 platform: windows      # string — system variable: "windows" | "macos" | "linux"
-chat_mode: chat-eco    # string — user variable: "normal" | "chat-eco"
+chat_mode: normal      # string — user variable: "normal" | "chat-eco"


### PR DESCRIPTION
## Summary

Adds the repository's standard GitHub community-health surface (RQ-GOV-001..008, ADR-GOV-001, PLAN-GOV-001):

- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1.
- **CONTRIBUTING.md** — fork/branch/PR workflow, plus a non-negotiable clause: any contribution prepared with an AI coding agent (GitHub Copilot or Claude Code) must follow this repository's AGNOS process (`.github/instructions/agnos-sw-eng.v2.instructions.md`, linked rather than duplicated).
- **`.github/ISSUE_TEMPLATE/bug_report.yml` & `feature_request.yml`** — structured GitHub Issue Forms with required fields, so bug/feature intake is unambiguous for the reporter, directly actionable for a maintainer, and reliably parseable/reformulable by an AI assistant (RQ-GOV-008). Blank issues are disabled (`config.yml`).
- **`.github/PULL_REQUEST_TEMPLATE.md`** — description, related issue, AGNOS traceability IDs, and an explicit checkbox confirming AGNOS was followed when an AI agent was used.
- **README.md** — new "Community" section pointing at the files above (replacing the old inline fork/branch/PR list), plus a correction to "What's new in the JUCE port": the keyboard-focus indicator claim is removed (no longer true since ADR-JUC-029 removed it) and the section now reflects the shipped window-size/scale, VFD bezel, MIDI-LED and menu-bar work (ADR-JUC-023/024/025/026/030/031/032).

Full traceability in `process/1.requirements/RQ-GOV-community-and-contribution.md`, `process/2.architecture/ADR-GOV-001-*.md`, and `process/3.plan/PLAN-GOV-001-*.md`.

## Test plan

- [x] No application code touched — documentation/governance files only, `unit_tests=false` for this session (owner-confirmed at session start).
- [x] Owner to preview `bug_report.yml` / `feature_request.yml` render correctly as GitHub Issue Forms once merged (Issue Forms can only be validated live on GitHub).
- [x] Owner to confirm `.github/PULL_REQUEST_TEMPLATE.md` pre-fills correctly on a real PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)