### PR TITLE
Fix page-family instance clicks sending the wrong page to the synth

### DIFF
--- a/juce/app/core/include/xplorer/app/PageFamilyModel.hpp
+++ b/juce/app/core/include/xplorer/app/PageFamilyModel.hpp
@@ -5,6 +5,8 @@
 // shared "_X_" control tags to concrete parameter names for the active
 // instance, and back. Headless-testable. [RQ-GUI-010..012, ADR-JUC-006]
 
+#include "xplorer/model/XpanderConstants.hpp"
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -17,6 +19,7 @@ namespace xplorer::app
         std::string parameterNamePrefix; ///< e.g. "ENV_"
         int digitIndex;                 ///< index of the instance digit in a concrete name
         int count;                      ///< number of instances (ENV=5 … TRACK=3)
+        model::EnumPages basePage;      ///< synth page of instance 1 (e.g. ENV_1); instances are contiguous
         std::vector<std::string> controlTags; ///< the "_X_" tags to refresh, in reference order
     };
 
@@ -37,4 +40,17 @@ namespace xplorer::app
         int instance;           ///< 1-based
     };
     [[nodiscard]] std::optional<FamilyParameter> familyParameterFor(const std::string& parameterName);
+
+    /// The concrete synth page for a family's 1-based instance
+    /// (e.g. (ENV_X, 3) → EnumPages::ENV_3). [RQ-CTL-028]
+    [[nodiscard]] int pageForInstance(const PageFamilyDescriptor& family, int instance);
+
+    /// Reverse of pageForInstance: which family and instance a synth page
+    /// belongs to; nullopt if the page is outside every family's range.
+    struct FamilyPage
+    {
+        std::string familyPrefix; ///< controlTagPrefix, e.g. "ENV_X"
+        int instance;             ///< 1-based
+    };
+    [[nodiscard]] std::optional<FamilyPage> familyPageFor(int page);
 }

--- a/juce/app/core/src/PageFamilyModel.cpp
+++ b/juce/app/core/src/PageFamilyModel.cpp
@@ -7,15 +7,15 @@ namespace xplorer::app
     const std::vector<PageFamilyDescriptor>& pageFamilies()
     {
         static const std::vector<PageFamilyDescriptor> families = {
-            {"ENV_X", "ENV_", 4, 5,
+            {"ENV_X", "ENV_", 4, 5, model::EnumPages::ENV_1,
              {"ENV_X_ATTACK", "ENV_X_DECAY", "ENV_X_DELAY", "ENV_X_MODE_DADR", "ENV_X_MODE_FREERUN",
               "ENV_X_MODE_RESET", "ENV_X_RELEASE", "ENV_X_SUSTAIN", "ENV_X_TRIG_EXTRIG",
               "ENV_X_TRIG_GATED", "ENV_X_TRIG_LFOTRIG", "ENV_X_TRIG_LFO_SOURCE",
               "ENV_X_TRIG_SINGLE_MULTI", "ENV_X_VOLUME"}},
-            {"LFO_X", "LFO_", 4, 5,
+            {"LFO_X", "LFO_", 4, 5, model::EnumPages::LFO_1,
              {"LFO_X_AMP", "LFO_X_LAG", "LFO_X_RETRIG", "LFO_X_RETRIG_MODE", "LFO_X_SAMPLE_INPUT",
               "LFO_X_SPEED", "LFO_X_WAVESHAPE"}},
-            {"RAMP_X", "RAMP_", 5, 4,
+            {"RAMP_X", "RAMP_", 5, 4, model::EnumPages::RAMP_1,
              {"RAMP_X_RATE", "RAMP_X_TRIG_EXTRIG", "RAMP_X_TRIG_GATED", "RAMP_X_TRIG_LFO_SOURCE",
               "RAMP_X_TRIG_LFOTRIG", "RAMP_X_TRIG_SINGLE_MULTI"}},
             // NOTE: the reference PageRefreshManager._pageTags lists the TRACK
@@ -24,7 +24,7 @@ namespace xplorer::app
             // keyed by tag, so in the reference the track points are never
             // refreshed on a TRACK instance switch (latent bug). This port
             // uses the real tags so they refresh correctly. [architecture-analysis_juce §11]
-            {"TRACK_X", "TRACK_", 6, 3,
+            {"TRACK_X", "TRACK_", 6, 3, model::EnumPages::TRACK_1,
              {"TRACK_X_IN", "TRACK_X_POINT_1", "TRACK_X_POINT_2", "TRACK_X_POINT_3",
               "TRACK_X_POINT_4", "TRACK_X_POINT_5"}},
         };
@@ -66,6 +66,25 @@ namespace xplorer::app
             result.familyPrefix = family.controlTagPrefix;
             result.instance = digit - '0';
             return result;
+        }
+        return std::nullopt;
+    }
+
+    int pageForInstance(const PageFamilyDescriptor& family, int instance)
+    {
+        return static_cast<int>(family.basePage) + instance - 1;
+    }
+
+    std::optional<FamilyPage> familyPageFor(int page)
+    {
+        for (const auto& family : pageFamilies())
+        {
+            const int first = static_cast<int>(family.basePage);
+            const int last = first + family.count - 1;
+            if (page >= first && page <= last)
+            {
+                return FamilyPage{family.controlTagPrefix, page - first + 1};
+            }
         }
         return std::nullopt;
     }

--- a/juce/app/src/MainComponent.cpp
+++ b/juce/app/src/MainComponent.cpp
@@ -290,28 +290,18 @@ namespace xplorer::app
 
     void MainComponent::onSynthPageChanged(const controller::PageChangeEvent& event)
     {
-        // Map the synth page to a family + instance and activate the selector. [RQ-GUI-012]
-        struct Range { model::EnumPages first; model::EnumPages last; const char* prefix; };
-        static const Range ranges[] = {
-            {model::EnumPages::ENV_1, model::EnumPages::ENV_5, "ENV_X"},
-            {model::EnumPages::LFO_1, model::EnumPages::LFO_5, "LFO_X"},
-            {model::EnumPages::RAMP_1, model::EnumPages::RAMP_4, "RAMP_X"},
-            {model::EnumPages::TRACK_1, model::EnumPages::TRACK_3, "TRACK_X"},
-        };
-        const int page = static_cast<int>(event.page);
-        for (const auto& range : ranges)
+        // Map the synth page to a family + instance and activate the selector,
+        // via the same family/page table selectInstance() uses to send. [RQ-GUI-012, RQ-CTL-028]
+        const auto familyPage = familyPageFor(static_cast<int>(event.page));
+        if (!familyPage)
         {
-            if (page >= static_cast<int>(range.first) && page <= static_cast<int>(range.last))
+            return;
+        }
+        for (auto& block : _familyBlocks)
+        {
+            if (block->familyPrefix() == familyPage->familyPrefix)
             {
-                const int instance = page - static_cast<int>(range.first) + 1;
-                for (auto& block : _familyBlocks)
-                {
-                    if (block->familyPrefix() == range.prefix)
-                    {
-                        block->setActiveInstanceFromSynth(instance);
-                    }
-                }
-                return;
+                block->setActiveInstanceFromSynth(familyPage->instance);
             }
         }
     }

--- a/juce/app/src/PageFamilyBlock.cpp
+++ b/juce/app/src/PageFamilyBlock.cpp
@@ -243,8 +243,9 @@ namespace xplorer::app
         _activeInstance = instance;
         if (notifySynth)
         {
-            // Reference RefreshPage: tell the synth to select this page. [RQ-GUI-011]
-            _controller.forceSendPageSubPage();
+            // Send the page-select for the instance just chosen (not
+            // whatever page was previously tracked). [RQ-GUI-011, RQ-CTL-028]
+            _controller.sendPageUpdate(pageForInstance(_descriptor, instance), 0);
         }
         rebindControlsToActiveInstance();
     }

--- a/juce/controller/include/xplorer/controller/XpanderController.hpp
+++ b/juce/controller/include/xplorer/controller/XpanderController.hpp
@@ -114,7 +114,11 @@ namespace xplorer::controller
         // --- synth utilities [RQ-CTL-060..062] --------------------------------
         void sendAllNotesOffToSynthOutput();
         void sendTuneRequestToSynth();
-        void sendPageUpdate(const std::string& pageName);
+        /// Sends a page-select SysEx for the given page/sub-page and records it
+        /// as the current one — used when the UI selects a page directly (e.g.
+        /// a page-family instance button), as opposed to forceSendPageSubPage()
+        /// which just re-sends whatever page is already tracked. [RQ-CTL-028]
+        void sendPageUpdate(int page, int subPage);
         void forceSendPageSubPage();
         void sendGreetingsToSynth();
         void sendTypeWriterMessageToSynth(const std::string& message);

--- a/juce/controller/src/XpanderController.cpp
+++ b/juce/controller/src/XpanderController.cpp
@@ -562,14 +562,12 @@ namespace xplorer::controller
         }
     }
 
-    void XpanderController::sendPageUpdate(const std::string& pageName)
+    void XpanderController::sendPageUpdate(int page, int subPage)
     {
-        // Reference parses the page name and force-sends unless it is the
-        // (dummy) CASSETTE fallback; only the side effect matters here.
-        if (!pageName.empty() && pageName != "CASSETTE")
-        {
-            forceSendPageSubPage();
-        }
+        // Unlike forceSendPageSubPage() (which re-sends whatever page/sub-page
+        // is already tracked), this sends AND tracks the given page, so a
+        // direct UI page selection is not lost behind a stale cached page. [RQ-CTL-028]
+        sendPageSubPageAndUpdatePageSubPage(page, subPage);
     }
 
     void XpanderController::forceSendPageSubPage()

--- a/juce/tests/app/PageFamilyModelTests.cpp
+++ b/juce/tests/app/PageFamilyModelTests.cpp
@@ -1,9 +1,11 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include "xplorer/app/PageFamilyModel.hpp"
+#include "xplorer/model/XpanderConstants.hpp"
 #include "xplorer/model/XpanderTone.hpp"
 
 using namespace xplorer::app;
+using xplorer::model::EnumPages;
 
 SCENARIO("Page families match the reference descriptors", "[RQ-GUI-010]")
 {
@@ -81,6 +83,41 @@ SCENARIO("Concrete parameter names map back to their family control tag", "[RQ-G
         {
             CHECK_FALSE(familyParameterFor("VCO1_FREQ").has_value());
             CHECK_FALSE(familyParameterFor("VCF_MODE").has_value());
+        }
+    }
+}
+
+SCENARIO("An instance resolves to its own concrete synth page", "[RQ-CTL-028]")
+{
+    GIVEN("the four families")
+    {
+        const auto& families = pageFamilies();
+
+        THEN("pageForInstance matches the reference page numbering, not just instance 1")
+        {
+            CHECK(pageForInstance(families[0], 1) == static_cast<int>(EnumPages::ENV_1));
+            CHECK(pageForInstance(families[0], 3) == static_cast<int>(EnumPages::ENV_3));
+            CHECK(pageForInstance(families[1], 5) == static_cast<int>(EnumPages::LFO_5));
+            CHECK(pageForInstance(families[3], 2) == static_cast<int>(EnumPages::TRACK_2));
+        }
+    }
+}
+
+SCENARIO("A concrete synth page maps back to its family and instance", "[RQ-GUI-012][RQ-CTL-028]")
+{
+    GIVEN("a page belonging to a family")
+    {
+        THEN("familyPageFor resolves the family prefix and 1-based instance")
+        {
+            const auto env = familyPageFor(static_cast<int>(EnumPages::ENV_3));
+            REQUIRE(env.has_value());
+            CHECK(env->familyPrefix == "ENV_X");
+            CHECK(env->instance == 3);
+        }
+
+        THEN("a page outside every family's range returns nothing")
+        {
+            CHECK_FALSE(familyPageFor(static_cast<int>(EnumPages::VCO_1_X)).has_value());
         }
     }
 }

--- a/juce/tests/controller/XpanderControllerTests.cpp
+++ b/juce/tests/controller/XpanderControllerTests.cpp
@@ -107,6 +107,46 @@ SCENARIO("The worker sends a page select before a parameter of another page", "[
     }
 }
 
+SCENARIO("Selecting a page directly sends and tracks that page, not a stale one", "[RQ-CTL-028]")
+{
+    GIVEN("a started controller (synchronized on VCO_1_X after first start)")
+    {
+        Fixture f;
+        f.controller.start();
+        f.backend.clearSentMessages();
+
+        WHEN("the UI selects ENV_3 directly, with no prior parameter edit")
+        {
+            f.controller.sendPageUpdate(static_cast<int>(model::EnumPages::ENV_3), 0);
+
+            THEN("the page-select frame targets ENV_3 (the selected page), not VCO_1_X")
+            {
+                REQUIRE(f.waitForSentCount(1));
+                const auto sent = f.backend.sentMessages(SYNTH_OUT);
+                CHECK(sent[0][3] == 0x0B); // page select opcode
+                CHECK(sent[0][4] == static_cast<int>(model::EnumPages::ENV_3));
+                CHECK(sent[0][5] == 0); // sub-page
+            }
+        }
+
+        WHEN("a page is selected and forceSendPageSubPage is called afterwards (e.g. a display resync)")
+        {
+            f.controller.sendPageUpdate(static_cast<int>(model::EnumPages::ENV_3), 0);
+            REQUIRE(f.waitForSentCount(1));
+            f.backend.clearSentMessages();
+
+            f.controller.forceSendPageSubPage();
+
+            THEN("it re-sends the newly selected page, proving the tracked page was updated")
+            {
+                REQUIRE(f.waitForSentCount(1));
+                const auto sent = f.backend.sentMessages(SYNTH_OUT);
+                CHECK(sent[0][4] == static_cast<int>(model::EnumPages::ENV_3));
+            }
+        }
+    }
+}
+
 SCENARIO("A single patch dump from the synth reloads the edited tone", "[RQ-CTL-021]")
 {
     GIVEN("a started controller and the OBERHEIM dump")

--- a/process/1.requirements/RQ-CTL-xplorer-controller.md
+++ b/process/1.requirements/RQ-CTL-xplorer-controller.md
@@ -23,6 +23,7 @@ Scope: C++ port of `Xplorer/Controller` (XpanderController and helpers). Extends
 - **RQ-CTL-025** — When the synth sends modulation-edit SysEx, the controller shall apply the command (change source, delete source, dial amount, set quantize, set sign, set unsigned value, toggle quantize) to the local matrix and raise a modulation-entry-change event.
 - **RQ-CTL-026** — When a multi-patch dump is detected, the controller shall ignore it without corrupting the edited tone (multi mode is out of scope, tracked as future work).
 - **RQ-CTL-027** — The controller shall raise a MIDI-activity event on message send/receive (drives the UI LED indicators).
+- **RQ-CTL-028** — When the user selects a page-family instance in the UI (e.g. clicking "ENV 2"), the controller shall send a page-select SysEx for that instance's own page — not the page/sub-page last tracked from an unrelated edit or synth echo — and update its tracked current page/sub-page to match.
 
 ## Modulation matrix operations
 


### PR DESCRIPTION
## Summary
- Clicking a page-family instance button (ENV1, ENV2, RAMP3, ...) always sent the same MIDI page-select SysEx — whatever page was last tracked from an unrelated parameter edit or synth echo — never the page corresponding to the button actually clicked, so the synth ignored it.
- Root cause: `PageFamilyBlock::selectInstance` called `XpanderController::forceSendPageSubPage()`, which only re-sends the cached "last known" page; nothing computed the target page for the clicked family+instance.
- Fix: added a canonical family+instance ↔ synth-page mapping (`PageFamilyModel::pageForInstance` / `familyPageFor`), routed the click through a corrected `XpanderController::sendPageUpdate(page, subPage)` that sends **and** tracks the explicit target page, and reused the same mapping in `MainComponent::onSynthPageChanged` (removing a duplicated hardcoded page-range table).
- New requirement `RQ-CTL-028` documents the intended behavior; `forceSendPageSubPage()` itself is untouched (still used for the existing "resync last known page" use case).

## Test plan
- [x] New unit tests: `PageFamilyModelTests.cpp` (`pageForInstance`/`familyPageFor`), `XpanderControllerTests.cpp` (`sendPageUpdate` sends+tracks the given page) — all passing (`xpl_tests_app`, `xpl_tests_controller`, 2022+110 assertions, no regressions).
- [x] Full GUI app (`XplorerApp`) builds clean under `/W4 /WX` (no warnings), confirming `PageFamilyBlock.cpp`/`MainComponent.cpp` compile correctly.
- [x] Manually verified against the real synth: clicking ENV/LFO/RAMP/TRACK instance buttons now sends the correct page-select SysEx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)